### PR TITLE
stripped leading "." from tab triggers per ST2 issue

### DIFF
--- a/$ajaxSend.sublime-snippet
+++ b/$ajaxSend.sublime-snippet
@@ -3,7 +3,7 @@
 	${2://stuff to do before an AJAX request is sent};
 });
 $0]]></content>
-	<tabTrigger>.ajaxsend</tabTrigger>
+	<tabTrigger>ajaxsend</tabTrigger>
 	<description>$.ajaxSend()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$ajaxSetup.sublime-snippet
+++ b/$ajaxSetup.sublime-snippet
@@ -15,7 +15,7 @@ ${2/(.+)/(?1:	type\: ':)/}${2:POST}${2/(.+)/(?1:',
 ${7/(.+)/(?1:	}
 :)/}});
 $0]]></content>
-	<tabTrigger>.ajaxsetup</tabTrigger>
+	<tabTrigger>ajaxsetup</tabTrigger>
 	<description>$.ajaxSetup()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$ajaxStart.sublime-snippet
+++ b/$ajaxStart.sublime-snippet
@@ -3,7 +3,7 @@
 	${1://stuff to do when an AJAX call is started and no other AJAX calls are in progress};
 });
 $0]]></content>
-	<tabTrigger>.ajaxstart</tabTrigger>
+	<tabTrigger>ajaxstart</tabTrigger>
 	<description>$.ajaxStart()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$ajaxStop.sublime-snippet
+++ b/$ajaxStop.sublime-snippet
@@ -3,7 +3,7 @@
 	${1://stuff to do when all AJAX calls have completed};
 });
 $0]]></content>
-	<tabTrigger>.ajaxstop</tabTrigger>
+	<tabTrigger>ajaxstop</tabTrigger>
 	<description>$.ajaxStop()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$ajaxSuccess.sublime-snippet
+++ b/$ajaxSuccess.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.ajaxSuccess(function(event, xhr, settings) {
 	${1:// executes whenever an AJAX request completes successfully}
 });$0]]></content>
-	<tabTrigger>.ajaxsuccess</tabTrigger>
+	<tabTrigger>ajaxsuccess</tabTrigger>
 	<description>$.ajaxSuccess()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$boxModel.sublime-snippet
+++ b/$boxModel.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[\$.boxModel(${1:DOMelementArray});
 $0]]></content>
-	<tabTrigger>.boxmodel</tabTrigger>
+	<tabTrigger>boxmodel</tabTrigger>
 	<description>$.boxModel()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$browser-version.sublime-snippet
+++ b/$browser-version.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\\$.browser.version]]></content>
-	<tabTrigger>.browser</tabTrigger>
+	<tabTrigger>browser</tabTrigger>
 	<description>$.browser.version</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$browser.sublime-snippet
+++ b/$browser.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.browser${1/(.+)/(?1:.:)/}${1:webkit/opera/msie/mozilla}${1/(.+)/(?1: :)/}$0]]></content>
-	<tabTrigger>.browser</tabTrigger>
+	<tabTrigger>browser</tabTrigger>
 	<description>$.browser()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$each.sublime-snippet
+++ b/$each.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[\$.each(${1:array/object}, function(${2:index}${3:, ${4:val}}) {
 	${0: //iterate through array or object}
 });]]></content>
-	<tabTrigger>.each</tabTrigger>
+	<tabTrigger>each</tabTrigger>
 	<description>$.each()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$extend.sublime-snippet
+++ b/$extend.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[\$.extend(${1:true, }${2:target object}, ${3:object1});
 $0]]></content>
-	<tabTrigger>.extend</tabTrigger>
+	<tabTrigger>extend</tabTrigger>
 	<description>$.extend()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$get.sublime-snippet
+++ b/$get.sublime-snippet
@@ -3,7 +3,7 @@
 	:)/}${3://optional stuff to do after success}${3/(.+)/(?1:
 }:)/});
 $0]]></content>
-	<tabTrigger>.get</tabTrigger>
+	<tabTrigger>get</tabTrigger>
 	<description>$.get()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$getScript.sublime-snippet
+++ b/$getScript.sublime-snippet
@@ -3,7 +3,7 @@
 	:)/}${2://optional stuff to do after getScript}${2/(.+)/(?1:
 }:)/});
 $0]]></content>
-	<tabTrigger>.get</tabTrigger>
+	<tabTrigger>get</tabTrigger>
 	<description>$.getScript()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$holdReady.sublime-snippet
+++ b/$holdReady.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\\$.holdReady(${1:true/false});]]></content>
-	<tabTrigger>.holdready</tabTrigger>
+	<tabTrigger>holdready</tabTrigger>
 	<description>$.holdReady</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$inArray.sublime-snippet
+++ b/$inArray.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.inArray(${1:value}, ${2:array});$0]]></content>
-	<tabTrigger>.inarray</tabTrigger>
+	<tabTrigger>inarray</tabTrigger>
 	<description>$.inArray()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$isEmptyObject.sublime-snippet
+++ b/$isEmptyObject.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.isEmptyObject('${1:object}');$0]]></content>
-	<tabTrigger>.is</tabTrigger>
+	<tabTrigger>is</tabTrigger>
 	<description>$.isEmptyObject()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$isNumeric.sublime-snippet
+++ b/$isNumeric.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.isNumeric('${1:object}');$0]]></content>
-	<tabTrigger>.is</tabTrigger>
+	<tabTrigger>is</tabTrigger>
 	<description>$.isNumeric()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$isPlainObject.sublime-snippet
+++ b/$isPlainObject.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.isPlainObject('${1:object}');$0]]></content>
-	<tabTrigger>.is</tabTrigger>
+	<tabTrigger>is</tabTrigger>
 	<description>$.isPlainObject()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$isWindow.sublime-snippet
+++ b/$isWindow.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.isWindow('${1:object}');$0]]></content>
-	<tabTrigger>.is</tabTrigger>
+	<tabTrigger>is</tabTrigger>
 	<description>$.isWindow()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$map.sublime-snippet
+++ b/$map.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[\$.map(${1:array}, function(${2:item}${3:, ${4:index}}) {
 	${5:return ${6:something};}
 });]]></content>
-	<tabTrigger>.map</tabTrigger>
+	<tabTrigger>map</tabTrigger>
 	<description>$.map()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$merge.sublime-snippet
+++ b/$merge.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.merge(${1:array1}, ${2:array2});]]></content>
-	<tabTrigger>.merge</tabTrigger>
+	<tabTrigger>merge</tabTrigger>
 	<description>$.merge()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$noop.sublime-snippet
+++ b/$noop.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.noop();$0]]></content>
-	<tabTrigger>.noop</tabTrigger>
+	<tabTrigger>noop</tabTrigger>
 	<description>$.noop()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$now.sublime-snippet
+++ b/$now.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.now();$0]]></content>
-	<tabTrigger>.now</tabTrigger>
+	<tabTrigger>now</tabTrigger>
 	<description>$.now()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$parseJSON.sublime-snippet
+++ b/$parseJSON.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.parseJSON('${1:json}');$0]]></content>
-	<tabTrigger>.parse</tabTrigger>
+	<tabTrigger>parse</tabTrigger>
 	<description>$.parseJSON()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$parseXML.sublime-snippet
+++ b/$parseXML.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.parseXML('${1:XML}');$0]]></content>
-	<tabTrigger>.parse</tabTrigger>
+	<tabTrigger>parse</tabTrigger>
 	<description>$.parseXML()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$post.sublime-snippet
+++ b/$post.sublime-snippet
@@ -3,7 +3,7 @@
 	:)/}${3://optional stuff to do after success}${3/(.+)/(?1:
 }:)/});
 $0]]></content>
-	<tabTrigger>.post</tabTrigger>
+	<tabTrigger>post</tabTrigger>
 	<description>$.post()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$sub.sublime-snippet
+++ b/$sub.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.sub();$0]]></content>
-	<tabTrigger>.sub</tabTrigger>
+	<tabTrigger>sub</tabTrigger>
 	<description>$.sub()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$trim.sublime-snippet
+++ b/$trim.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.trim(${1:'${2:string}'})$0]]></content>
-	<tabTrigger>.trim</tabTrigger>
+	<tabTrigger>trim</tabTrigger>
 	<description>$.trim()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$type.sublime-snippet
+++ b/$type.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[\$.type(${1:DOMelementArray});$0]]></content>
-	<tabTrigger>.type</tabTrigger>
+	<tabTrigger>type</tabTrigger>
 	<description>$.type()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$unique.sublime-snippet
+++ b/$unique.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[\$.unique(${1:DOMelementArray});
 $0]]></content>
-	<tabTrigger>.unique</tabTrigger>
+	<tabTrigger>unique</tabTrigger>
 	<description>$.unique()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/$when.sublime-snippet
+++ b/$when.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[\$.when(${1:deferreds});
 $0]]></content>
-	<tabTrigger>.when</tabTrigger>
+	<tabTrigger>when</tabTrigger>
 	<description>$.when()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/add.sublime-snippet
+++ b/add.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.add('${1:selector/elements/html}')$0]]></content>
-	<tabTrigger>.add</tabTrigger>
+	<tabTrigger>add</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/addClass.sublime-snippet
+++ b/addClass.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.addClass('${1:class_name}')$0]]></content>
-	<tabTrigger>.addClass</tabTrigger>
+	<tabTrigger>addClass</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/after.sublime-snippet
+++ b/after.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.after('${1:Some text &lt;b&gt;and bold!&lt;/b&gt;}')$0]]></content>
-	<tabTrigger>.after</tabTrigger>
+	<tabTrigger>after</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/ajax.sublime-snippet
+++ b/ajax.sublime-snippet
@@ -15,6 +15,6 @@ ${2/(.+)/(?1:  type\: ':)/}${2:POST}${2/(.+)/(?1:',
 ${7/(.+)/(?1:  }
 :)/}});
 $0]]></content>
-	<tabTrigger>.ajax</tabTrigger>
+	<tabTrigger>ajax</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/ajaxComplete.sublime-snippet
+++ b/ajaxComplete.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.ajaxComplete(function(event, xhr, settings) {
 	${1:// executes whenever an AJAX request completes}
 });$0]]></content>
-	<tabTrigger>.ajaxComplete</tabTrigger>
+	<tabTrigger>ajaxComplete</tabTrigger>
 	<description>.ajaxComplete()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/ajaxError.sublime-snippet
+++ b/ajaxError.sublime-snippet
@@ -3,6 +3,6 @@
   ${2://stuff to do when an AJAX call returns an error};
 });
 $0]]></content>
-	<tabTrigger>.ajaxerror</tabTrigger>
+	<tabTrigger>ajaxerror</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/andSelf.sublime-snippet
+++ b/andSelf.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.andSelf()$0]]></content>
-	<tabTrigger>.andSelf</tabTrigger>
+	<tabTrigger>andSelf</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/animate-(with-callback).sublime-snippet
+++ b/animate-(with-callback).sublime-snippet
@@ -5,7 +5,7 @@
 	${7:speed}, function() {
 	${0:// stuff to do after animation is complete}
 });]]></content>
-	<tabTrigger>.animate</tabTrigger>
+	<tabTrigger>animate</tabTrigger>
 	<description>.animate() with callback</description>
 	<scope>source.js</scope>
 </snippet>

--- a/animate.sublime-snippet
+++ b/animate.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.animate({${1:${2:param1}: ${3:value1}${4:, ${5:param2}: ${6:value2}}}}, ${7:speed})$0]]></content>
-	<tabTrigger>.animate</tabTrigger>
+	<tabTrigger>animate</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/append.sublime-snippet
+++ b/append.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.append('${1:Some text &lt;b&gt;and bold!&lt;/b&gt;}')$0]]></content>
-	<tabTrigger>.append</tabTrigger>
+	<tabTrigger>append</tabTrigger>
 	<description>.append</description>
 	<scope>source.js</scope>
 </snippet>

--- a/appendTo.sublime-snippet
+++ b/appendTo.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.appendTo('${1:selector expression}')$0]]></content>
-	<tabTrigger>.appendTo</tabTrigger>
+	<tabTrigger>appendTo</tabTrigger>
 	<description>.appendTo</description>
 	<scope>source.js</scope>
 </snippet>

--- a/attr-multiple.sublime-snippet
+++ b/attr-multiple.sublime-snippet
@@ -3,7 +3,7 @@
 	${1:property1}: '${2:value1}'${3:,
 	${4:property2}: '${5:value2}'
 \}});$0]]></content>
-	<tabTrigger>.attr</tabTrigger>
+	<tabTrigger>attr</tabTrigger>
 	<description>.attr() - multiple</description>
 	<scope>source.js</scope>
 </snippet>

--- a/attr.sublime-snippet
+++ b/attr.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.attr('${1:attribute}', '${2:value}');$0]]></content>
-	<tabTrigger>.attr</tabTrigger>
+	<tabTrigger>attr</tabTrigger>
 	<description>.attr() - single</description>
 	<scope>source.js</scope>
 </snippet>

--- a/before.sublime-snippet
+++ b/before.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.before('${1:content}');$0]]></content>
-	<tabTrigger>.before</tabTrigger>
+	<tabTrigger>before</tabTrigger>
 	<description>.before()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/bind.sublime-snippet
+++ b/bind.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.bind('${1:event name}'${2/(^,).*|.+/(?1::, )/}${2:eventData}, function(${3:event}) {
 	${0:// Act on the event}
 });]]></content>
-	<tabTrigger>.bind</tabTrigger>
+	<tabTrigger>bind</tabTrigger>
 	<description>.bind</description>
 	<scope>source.js</scope>
 </snippet>

--- a/blur.sublime-snippet
+++ b/blur.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.blur(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.blur</tabTrigger>
+	<tabTrigger>blur</tabTrigger>
 	<description>.blur</description>
 	<scope>source.js</scope>
 </snippet>

--- a/change.sublime-snippet
+++ b/change.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.change(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.change</tabTrigger>
+	<tabTrigger>change</tabTrigger>
 	<description>.change</description>
 	<scope>source.js</scope>
 </snippet>

--- a/children.sublime-snippet
+++ b/children.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.children(${1/(.+)/(?1:':)/}${1:selector expression}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.children</tabTrigger>
+	<tabTrigger>children</tabTrigger>
 	<description>.children</description>
 	<scope>source.js</scope>
 </snippet>

--- a/clearqueue.sublime-snippet
+++ b/clearqueue.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.clearQueue(${1:queueName});$0]]></content>
-	<tabTrigger>.clearQueue</tabTrigger>
+	<tabTrigger>clearQueue</tabTrigger>
 	<description>.clearQueue()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/click.sublime-snippet
+++ b/click.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.click(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.click</tabTrigger>
+	<tabTrigger>click</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/clone.sublime-snippet
+++ b/clone.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.clone(${1:withDataAndEvents}${2/(^,).*|.+/(?1::, )/}${2:deepWithDataAndEvents})$0]]></content>
-	<tabTrigger>.clone</tabTrigger>
+	<tabTrigger>clone</tabTrigger>
 	<description>.clone</description>
 	<scope>source.js</scope>
 </snippet>

--- a/closest.sublime-snippet
+++ b/closest.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.closest('${1:selector expression}')$0]]></content>
-	<tabTrigger>.closest</tabTrigger>
+	<tabTrigger>closest</tabTrigger>
 	<description>.closest</description>
 	<scope>source.js</scope>
 </snippet>

--- a/contains.sublime-snippet
+++ b/contains.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.contains('${1:text to find}');$0]]></content>
-	<tabTrigger>.contains</tabTrigger>
+	<tabTrigger>contains</tabTrigger>
 	<description>.contains()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/contents.sublime-snippet
+++ b/contents.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.contents();$0]]></content>
-	<tabTrigger>.contents</tabTrigger>
+	<tabTrigger>contents</tabTrigger>
 	<description>.contents()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/css-multiple.sublime-snippet
+++ b/css-multiple.sublime-snippet
@@ -3,7 +3,7 @@
 	${1:property1}: '${2:value1}'${3:,
 	${4:property2}: '${5:value2}'
 \}});$0]]></content>
-	<tabTrigger>.css</tabTrigger>
+	<tabTrigger>css</tabTrigger>
 	<description>.css() - multiple</description>
 	<scope>source.js</scope>
 </snippet>

--- a/css.sublime-snippet
+++ b/css.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.css('${1:property}', '${2:value}');$0]]></content>
-	<tabTrigger>.css</tabTrigger>
+	<tabTrigger>css</tabTrigger>
 	<description>.css() - single</description>
 	<scope>source.js</scope>
 </snippet>

--- a/data.sublime-snippet
+++ b/data.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.data('${1:data}'${2/(.+)/(?1:, :)/}${2/(^[0-9]+$)|.+/(?1::')/}${2:value}${2/(^[0-9]+$)|.+/(?1::')/})$0]]></content>
-	<tabTrigger>.data</tabTrigger>
+	<tabTrigger>data</tabTrigger>
 	<description>.data</description>
 	<scope>source.js</scope>
 </snippet>

--- a/dblclick.sublime-snippet
+++ b/dblclick.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.dblclick(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.dblclick</tabTrigger>
+	<tabTrigger>dblclick</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/delay.sublime-snippet
+++ b/delay.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.delay(${1:milliseconds}${2/^([^,]|\w).*$|.+/(?1:, :)/}${2:queueName})$0]]></content>
-	<tabTrigger>.delay</tabTrigger>
+	<tabTrigger>delay</tabTrigger>
 	<description>.delay</description>
 	<scope>source.js</scope>
 </snippet>

--- a/delegate.sublime-snippet
+++ b/delegate.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.delegate('${1:selector}', '${2:event type(s)}'${3/(^{).*|.+/(?1::, {)/}${3:value}${3/(^(}.+$|,.*))|.+/(?1::})/}, function(${4:event}) {
 	${0:// Act on the event}
 });]]></content>
-	<tabTrigger>.delegate</tabTrigger>
+	<tabTrigger>delegate</tabTrigger>
 	<description>.delegate</description>
 	<scope>source.js</scope>
 </snippet>

--- a/dequeue.sublime-snippet
+++ b/dequeue.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.dequeue(${1/(.+)/(?1:':)/}${1:queueName}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.dequeue</tabTrigger>
+	<tabTrigger>dequeue</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/die.sublime-snippet
+++ b/die.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.die('${1:eventType}')$0]]></content>
-	<tabTrigger>.die</tabTrigger>
+	<tabTrigger>die</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/each.sublime-snippet
+++ b/each.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.each(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.each</tabTrigger>
+	<tabTrigger>each</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/end.sublime-snippet
+++ b/end.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.end()$0]]></content>
-	<tabTrigger>.end</tabTrigger>
+	<tabTrigger>end</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/eq.sublime-snippet
+++ b/eq.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.eq(${1:index})$0]]></content>
-	<tabTrigger>.eq</tabTrigger>
+	<tabTrigger>eq</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/error.sublime-snippet
+++ b/error.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.error(${1:function() {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.error</tabTrigger>
+	<tabTrigger>error</tabTrigger>
 	<description>.error()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/fadeIn.sublime-snippet
+++ b/fadeIn.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.fadeIn(${1:'slow/400/fast'}${2:, function() {
 	$3
 \}});$0]]></content>
-	<tabTrigger>.fadeIn</tabTrigger>
+	<tabTrigger>fadeIn</tabTrigger>
 	<description>.fadeIn()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/fadeOut.sublime-snippet
+++ b/fadeOut.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.fadeOut('${1:slow/400/fast}'${2:, function() {
 	$3
 \}});$0]]></content>
-	<tabTrigger>.fadeOut</tabTrigger>
+	<tabTrigger>fadeOut</tabTrigger>
 	<description>.fadeOut()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/fadeTo.sublime-snippet
+++ b/fadeTo.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.fadeTo('${1:slow/400/fast}', ${2:0.5}${3:, function() {
 	$4
 \}});$0]]></content>
-	<tabTrigger>.fadeto</tabTrigger>
+	<tabTrigger>fadeto</tabTrigger>
 	<description>.fadeTo()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/fadeToggle.sublime-snippet
+++ b/fadeToggle.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.fadeToggle('${1:slow/400/fast}'${2:, function() {
 	$3
 \}});$0]]></content>
-	<tabTrigger>.fadeToggle</tabTrigger>
+	<tabTrigger>fadeToggle</tabTrigger>
 	<description>.fadeToggle()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/filter-function.sublime-snippet
+++ b/filter-function.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.filter(function(index) {
 	${1:return ${2:something};}
 });$0]]></content>
-	<tabTrigger>.filter</tabTrigger>
+	<tabTrigger>filter</tabTrigger>
 	<description>.filter function</description>
 	<scope>source.js</scope>
 </snippet>

--- a/filter.sublime-snippet
+++ b/filter.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.filter($1);$0]]></content>
-	<tabTrigger>.filter</tabTrigger>
+	<tabTrigger>filter</tabTrigger>
 	<description>.filter()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/find.sublime-snippet
+++ b/find.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.find('${1:selector expression}')$0]]></content>
-	<tabTrigger>.find</tabTrigger>
+	<tabTrigger>find</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/first.sublime-snippet
+++ b/first.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.first()$0]]></content>
-	<tabTrigger>.first</tabTrigger>
+	<tabTrigger>first</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/focus.sublime-snippet
+++ b/focus.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.focus(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.focus</tabTrigger>
+	<tabTrigger>focus</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/focusin.sublime-snippet
+++ b/focusin.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.focusin(${1:function(${2:event}) {
 	${3:// Act on the event}
 \}});$0]]></content>
-	<tabTrigger>.focusin</tabTrigger>
+	<tabTrigger>focusin</tabTrigger>
 	<description>.focusin()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/focusout.sublime-snippet
+++ b/focusout.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.focusout(${1:function(${2:event}) {
 	${3:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.focusout</tabTrigger>
+	<tabTrigger>focusout</tabTrigger>
 	<description>.focusout()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/get.sublime-snippet
+++ b/get.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.get(${1:element index})$0]]></content>
-	<tabTrigger>.get</tabTrigger>
+	<tabTrigger>get</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/getJSON.sublime-snippet
+++ b/getJSON.sublime-snippet
@@ -3,7 +3,7 @@
 	:)/}${3://optional stuff to do after success}${3/(.+)/(?1:
 }:)/});
 $0]]></content>
-	<tabTrigger>.getjson</tabTrigger>
+	<tabTrigger>getjson</tabTrigger>
 	<description>$.getjson()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/has.sublime-snippet
+++ b/has.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.has(${1/(.+)/(?1:':)/}${1:contained selector/element}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.has</tabTrigger>
+	<tabTrigger>has</tabTrigger>
 	<description>.has</description>
 	<scope>source.js</scope>
 </snippet>

--- a/hasClass.sublime-snippet
+++ b/hasClass.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.hasClass('${1:className}')$0]]></content>
-	<tabTrigger>.hasClass</tabTrigger>
+	<tabTrigger>hasClass</tabTrigger>
 	<description>.hasClass</description>
 	<scope>source.js</scope>
 </snippet>

--- a/height.sublime-snippet
+++ b/height.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.height(${1:integer})$0]]></content>
-	<tabTrigger>.height</tabTrigger>
+	<tabTrigger>height</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/hide.sublime-snippet
+++ b/hide.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.hide('${1:slow/400/fast}'${2:, function() {
 	$3
 \}});$0]]></content>
-	<tabTrigger>.hide</tabTrigger>
+	<tabTrigger>hide</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/hover.sublime-snippet
+++ b/hover.sublime-snippet
@@ -4,6 +4,6 @@
 }, function() {
 	${2:// Stuff to do when the mouse leaves the element;}
 });$0]]></content>
-	<tabTrigger>.hover</tabTrigger>
+	<tabTrigger>hover</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/html.sublime-snippet
+++ b/html.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.html(${1/(.+)/(?1:':)/}${1:Some text &lt;b&gt;and bold!&lt;/b&gt;}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.html</tabTrigger>
+	<tabTrigger>html</tabTrigger>
 	<description>.html</description>
 	<scope>source.js</scope>
 </snippet>

--- a/index.sublime-snippet
+++ b/index.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.index(${1/(.+)/(?1:':)/}${1:selector/element}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.index</tabTrigger>
+	<tabTrigger>index</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/innerHeight.sublime-snippet
+++ b/innerHeight.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.innerHeight()$0]]></content>
-	<tabTrigger>.innerHeight</tabTrigger>
+	<tabTrigger>innerHeight</tabTrigger>
 	<description>.innerHeight</description>
 	<scope>source.js</scope>
 </snippet>

--- a/innerWidth.sublime-snippet
+++ b/innerWidth.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.innerWidth()$0]]></content>
-	<tabTrigger>.innerWidth</tabTrigger>
+	<tabTrigger>innerWidth</tabTrigger>
 	<description>.innerWidth</description>
 	<scope>source.js</scope>
 </snippet>

--- a/insertAfter.sublime-snippet
+++ b/insertAfter.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.insertAfter('${1:selector expression}')$0]]></content>
-	<tabTrigger>.insertAfter</tabTrigger>
+	<tabTrigger>insertAfter</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/insertBefore.sublime-snippet
+++ b/insertBefore.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.insertBefore('${1:selector expression}')$0]]></content>
-	<tabTrigger>.insertBefore</tabTrigger>
+	<tabTrigger>insertBefore</tabTrigger>
 	<description>.insertBefore</description>
 	<scope>source.js</scope>
 </snippet>

--- a/is.sublime-snippet
+++ b/is.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.is('${1:selector expression}')$0]]></content>
-	<tabTrigger>.is</tabTrigger>
+	<tabTrigger>is</tabTrigger>
 	<decscription>.is()</decscription>
 	<scope>source.js</scope>
 </snippet>

--- a/keydown.sublime-snippet
+++ b/keydown.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.keydown(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.keydown</tabTrigger>
+	<tabTrigger>keydown</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/keypress.sublime-snippet
+++ b/keypress.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.keypress(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.keypress</tabTrigger>
+	<tabTrigger>keypress</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/keyup.sublime-snippet
+++ b/keyup.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.keyup(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.keyup</tabTrigger>
+	<tabTrigger>keyup</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/last.sublime-snippet
+++ b/last.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.last()$0]]></content>
-	<tabTrigger>.last</tabTrigger>
+	<tabTrigger>last</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/live.sublime-snippet
+++ b/live.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.live('${1:click}', function(${2:event}) {
 	${0:// Act on the event}
 });]]></content>
-	<tabTrigger>.live</tabTrigger>
+	<tabTrigger>live</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/load.sublime-snippet
+++ b/load.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.load(${1:function() {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.load</tabTrigger>
+	<tabTrigger>load</tabTrigger>
 	<description>.load</description>
 	<scope>source.js</scope>
 </snippet>

--- a/loadAHAH.sublime-snippet
+++ b/loadAHAH.sublime-snippet
@@ -5,7 +5,7 @@
 		:)/}${3:// Stuff to do after the page is loaded}${3/(.+)/(?1:
 	}:)/});
 $0]]></content>
-	<tabTrigger>.load</tabTrigger>
+	<tabTrigger>load</tabTrigger>
 	<description>.load</description>
 	<scope>source.js</scope>
 </snippet>

--- a/map.sublime-snippet
+++ b/map.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.map(function(${1:index}${2:, ${3:elem}}) {
 	${4:return ${5:something};}
 })]]></content>
-	<tabTrigger>.map</tabTrigger>
+	<tabTrigger>map</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/mousedown.sublime-snippet
+++ b/mousedown.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.mousedown(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.mousedown</tabTrigger>
+	<tabTrigger>mousedown</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/mouseenter.sublime-snippet
+++ b/mouseenter.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.mouseenter(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.mouseenter</tabTrigger>
+	<tabTrigger>mouseenter</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/mouseleave.sublime-snippet
+++ b/mouseleave.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.mouseleave(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.mouseleave</tabTrigger>
+	<tabTrigger>mouseleave</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/mousemove.sublime-snippet
+++ b/mousemove.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.mousemove(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.mousemove</tabTrigger>
+	<tabTrigger>mousemove</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/mouseout.sublime-snippet
+++ b/mouseout.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.mouseout(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.mouseout</tabTrigger>
+	<tabTrigger>mouseout</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/mouseover.sublime-snippet
+++ b/mouseover.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.mouseover(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.mouseover</tabTrigger>
+	<tabTrigger>mouseover</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/mouseup.sublime-snippet
+++ b/mouseup.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.mouseup(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.mouseup</tabTrigger>
+	<tabTrigger>mouseup</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/next.sublime-snippet
+++ b/next.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.next(${1/(.+)/(?1:':)/}${1:selector}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.next</tabTrigger>
+	<tabTrigger>next</tabTrigger>
 	<description>.next</description>
 	<scope>source.js</scope>
 </snippet>

--- a/nextAll.sublime-snippet
+++ b/nextAll.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.nextAll(${1/(.+)/(?1:':)/}${1:selector}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.nextAll</tabTrigger>
+	<tabTrigger>nextAll</tabTrigger>
 	<description>.nextAll</description>
 	<scope>source.js</scope>
 </snippet>

--- a/nextUntil.sublime-snippet
+++ b/nextUntil.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.nextUntil(${1/(.+)/(?1:':)/}${1:selector}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.nextUntil</tabTrigger>
+	<tabTrigger>nextUntil</tabTrigger>
 	<description>.nextUntil</description>
 	<scope>source.js</scope>
 </snippet>

--- a/not.sublime-snippet
+++ b/not.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.not('${1:selector expression}')$0]]></content>
-	<tabTrigger>.not</tabTrigger>
+	<tabTrigger>not</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/off.sublime-snippet
+++ b/off.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.off();]]></content>
-	<tabTrigger>.off</tabTrigger>
+	<tabTrigger>off</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/offset (function).sublime-snippet
+++ b/offset (function).sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.offset(function(index, currentCoordinates) {
 	${1:return ${2:someObject};}
 })]]></content>
-	<tabTrigger>.offset</tabTrigger>
+	<tabTrigger>offset</tabTrigger>
 	<description>.offset</description>
 	<scope>source.js</scope>
 </snippet>

--- a/offset.sublime-snippet
+++ b/offset.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.offset(${1/(.+)/(?1:{:)/}${1:coordinates}${1/(.+)/(?1:}:)/})$0]]></content>
-	<tabTrigger>.offset</tabTrigger>
+	<tabTrigger>offset</tabTrigger>
 	<description>.offset</description>
 	<scope>source.js</scope>
 </snippet>

--- a/offsetParent.sublime-snippet
+++ b/offsetParent.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.offsetParent();$0]]></content>
-	<tabTrigger>.offsetParent</tabTrigger>
+	<tabTrigger>offsetParent</tabTrigger>
 	<description>.offsetParent()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/on.sublime-snippet
+++ b/on.sublime-snippet
@@ -3,7 +3,7 @@
 	${5:event.preventDefault();}
 	${6:// Act on the event}
 });]]></content>
-	<tabTrigger>.on</tabTrigger>
+	<tabTrigger>on</tabTrigger>
 	<description>.on()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/one.sublime-snippet
+++ b/one.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.one('${1:event name}', function(${2:event}) {
 	${0:// Act on the event once}
 });]]></content>
-	<tabTrigger>.one</tabTrigger>
+	<tabTrigger>one</tabTrigger>
 	<description>.one</description>
 	<scope>source.js</scope>
 </snippet>

--- a/outerHeight.sublime-snippet
+++ b/outerHeight.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.outerHeight()$0]]></content>
-	<tabTrigger>.outerHeight</tabTrigger>
+	<tabTrigger>outerHeight</tabTrigger>
 	<description>.outerHeight</description>
 	<scope>source.js</scope>
 </snippet>

--- a/outerWidth.sublime-snippet
+++ b/outerWidth.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.outerWidth()$0]]></content>
-	<tabTrigger>.outerWidth</tabTrigger>
+	<tabTrigger>outerWidth</tabTrigger>
 	<description>.outerWidth</description>
 	<scope>source.js</scope>
 </snippet>

--- a/parent.sublime-snippet
+++ b/parent.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.parent(${1/(.+)/(?1:':)/}${1:selector expression}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.parent</tabTrigger>
+	<tabTrigger>parent</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/parents.sublime-snippet
+++ b/parents.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.parents(${1/(.+)/(?1:':)/}${1:selector expression}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.parents</tabTrigger>
+	<tabTrigger>parents</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/parentsUntil.sublime-snippet
+++ b/parentsUntil.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.parentsUntil(${1/(.+)/(?1:':)/}${1:selector}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.parentsUntil</tabTrigger>
+	<tabTrigger>parentsUntil</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/prepend.sublime-snippet
+++ b/prepend.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.prepend('${1:Some text &lt;b&gt;and bold!&lt;/b&gt;}')$0]]></content>
-	<tabTrigger>.prepend</tabTrigger>
+	<tabTrigger>prepend</tabTrigger>
 	<description>.prepend</description>
 	<scope>source.js</scope>
 </snippet>

--- a/prependTo.sublime-snippet
+++ b/prependTo.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.prependTo('${1:selector expression}')$0]]></content>
-	<tabTrigger>.prependTo</tabTrigger>
+	<tabTrigger>prependTo</tabTrigger>
 	<description>.prependTo</description>
 	<scope>source.js</scope>
 </snippet>

--- a/prev.sublime-snippet
+++ b/prev.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.prev(${1/(.+)/(?1:':)/}${1:selector expression}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.prev</tabTrigger>
+	<tabTrigger>prev</tabTrigger>
 	<description>.prev</description>
 	<scope>source.js</scope>
 </snippet>

--- a/prevAll.sublime-snippet
+++ b/prevAll.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.prevAll(${1/(.+)/(?1:':)/}${1:selector}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.prevAll</tabTrigger>
+	<tabTrigger>prevAll</tabTrigger>
 	<description>.prevAll</description>
 	<scope>source.js</scope>
 </snippet>

--- a/prevUntil.sublime-snippet
+++ b/prevUntil.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.prevUntil(${1/(.+)/(?1:':)/}${1:selector}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.prevUntil</tabTrigger>
+	<tabTrigger>prevUntil</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/prop(map).sublime-snippet
+++ b/prop(map).sublime-snippet
@@ -3,6 +3,6 @@
 	${1:property1}: '${2:value1}'},
 	${3:property2}: '${4:value2}'},
 })$0]]></content>
-	<tabTrigger>.prop</tabTrigger>
+	<tabTrigger>prop</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/prop.sublime-snippet
+++ b/prop.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.prop('${1:property}'${2/(^,).*|.+/(?1::, )/}${2/(^([0-9]+$|,.*))|.+/(?1::')/}${2:value}${2/(^([0-9]+$|,.*))|.+/(?1::')/})$0]]></content>
-	<tabTrigger>.prop</tabTrigger>
+	<tabTrigger>prop</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/reject.sublime-snippet
+++ b/reject.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.reject(${1:args})$0]]></content>
-	<tabTrigger>.reject</tabTrigger>
+	<tabTrigger>reject</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/remove.sublime-snippet
+++ b/remove.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.remove()$0]]></content>
-	<tabTrigger>.remove</tabTrigger>
+	<tabTrigger>remove</tabTrigger>
 	<description>.remove</description>
 	<scope>source.js</scope>
 </snippet>

--- a/removeAttr.sublime-snippet
+++ b/removeAttr.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.removeAttr('${1:attribute name}')$0]]></content>
-	<tabTrigger>.removeAttr</tabTrigger>
+	<tabTrigger>removeAttr</tabTrigger>
 	<description>.removeAttr</description>
 	<scope>source.js</scope>
 </snippet>

--- a/removeClass.sublime-snippet
+++ b/removeClass.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.removeClass('${1:class name}')$0]]></content>
-	<tabTrigger>.removeClass</tabTrigger>
+	<tabTrigger>removeClass</tabTrigger>
 	<description>.removeClass</description>
 	<scope>source.js</scope>
 </snippet>

--- a/removeData.sublime-snippet
+++ b/removeData.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.removeData('${1:data name}')$0]]></content>
-	<tabTrigger>.removeData</tabTrigger>
+	<tabTrigger>removeData</tabTrigger>
 	<description>.removeData</description>
 	<scope>source.js</scope>
 </snippet>

--- a/replaceAll.sublime-snippet
+++ b/replaceAll.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.replaceAll('${1:data name}')$0]]></content>
-	<tabTrigger>.replaceAll</tabTrigger>
+	<tabTrigger>replaceAll</tabTrigger>
 	<description>.replaceAll</description>
 	<scope>source.js</scope>
 </snippet>

--- a/replaceWith.sublime-snippet
+++ b/replaceWith.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.replaceWith('${1:htmlString/DOMElement/jQueryObject}'${2:, function() {
 	$3
 \}});$0]]></content>
-	<tabTrigger>.replaceWith</tabTrigger>
+	<tabTrigger>replaceWith</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/reset.sublime-snippet
+++ b/reset.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.reset(${1:function(${2:event}) {
 	${2:// Act on the event}
 \}});$0]]></content>
-	<tabTrigger>.reset</tabTrigger>
+	<tabTrigger>reset</tabTrigger>
 	<description>.reset()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/resize.sublime-snippet
+++ b/resize.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.resize(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.resize</tabTrigger>
+	<tabTrigger>resize</tabTrigger>
 	<description>.resize</description>
 	<scope>source.js</scope>
 </snippet>

--- a/resolve.sublime-snippet
+++ b/resolve.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.resolve(${1:args})$0]]></content>
-	<tabTrigger>.resolve</tabTrigger>
+	<tabTrigger>resolve</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/resolveWith.sublime-snippet
+++ b/resolveWith.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.resolveWith(${1:context}${2/(^,).*|.+/(?1::, )/}${2:args})$0]]></content>
-	<tabTrigger>.resolveWith</tabTrigger>
+	<tabTrigger>resolveWith</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/scroll.sublime-snippet
+++ b/scroll.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.scroll(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.scroll</tabTrigger>
+	<tabTrigger>scroll</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/scrollLeft.sublime-snippet
+++ b/scrollLeft.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.scrollLeft(${1:value})$0]]></content>
-	<tabTrigger>.scrollLeft</tabTrigger>
+	<tabTrigger>scrollLeft</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/scrollTop.sublime-snippet
+++ b/scrollTop.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.scrollTop(${1:value})$0]]></content>
-	<tabTrigger>.scrollTop</tabTrigger>
+	<tabTrigger>scrollTop</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/select.sublime-snippet
+++ b/select.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.select(${1:function(${2:event}) {
 	${2:// Act on the event}
 \}});$0]]></content>
-	<tabTrigger>.select</tabTrigger>
+	<tabTrigger>select</tabTrigger>
 	<description>.select()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/serialize.sublime-snippet
+++ b/serialize.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.serialize()$0]]></content>
-	<tabTrigger>.serialize</tabTrigger>
+	<tabTrigger>serialize</tabTrigger>
 	<description>.serialize()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/serializeArray.sublime-snippet
+++ b/serializeArray.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.serializeArray()$0]]></content>
-	<tabTrigger>.serializeArray</tabTrigger>
+	<tabTrigger>serializeArray</tabTrigger>
 	<description>.serializeArray()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/show.sublime-snippet
+++ b/show.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.show('${1:slow/400/fast}'${2:, function() {
 	$3
 \}});$0]]></content>
-	<tabTrigger>.show</tabTrigger>
+	<tabTrigger>show</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/siblings.sublime-snippet
+++ b/siblings.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.siblings(${1/(.+)/(?1:':)/}${1:selector expression}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.siblings</tabTrigger>
+	<tabTrigger>siblings</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/size.sublime-snippet
+++ b/size.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.size();$0]]></content>
-	<tabTrigger>.size</tabTrigger>
+	<tabTrigger>size</tabTrigger>
 	<description>.size()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/slice.sublime-snippet
+++ b/slice.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.slice(${1:start}${2/^([^,]|\d).*$|.+/(?1:, :)/}${2:end})$0]]></content>
-	<tabTrigger>.slice</tabTrigger>
+	<tabTrigger>slice</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/slideDown.sublime-snippet
+++ b/slideDown.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[.slideDown('${1:slow/400/fast}'${2:, function() {
 	$3
 \}});$0]]></content>
-	<tabTrigger>.slideDown</tabTrigger>
+	<tabTrigger>slideDown</tabTrigger>
 	<description>.slideDown()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/slideToggle.sublime-snippet
+++ b/slideToggle.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.slideToggle(${1/(^[0-9]+$)|.+/(?1::')/}${1:slow/400/fast}${1/(^[0-9]+$)|.+/(?1::')/})$0]]></content>
-	<tabTrigger>.slideToggle</tabTrigger>
+	<tabTrigger>slideToggle</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/slideUp.sublime-snippet
+++ b/slideUp.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.slideUp(${1/(^[0-9]+$)|.+/(?1::')/}${1:slow/400/fast}${1/(^[0-9]+$)|.+/(?1::')/})$0]]></content>
-	<tabTrigger>.slideUp</tabTrigger>
+	<tabTrigger>slideUp</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/stop.sublime-snippet
+++ b/stop.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.stop(${1:clearQueue}${2/^([^,]|\w).*$|.+/(?1:, :)/}${2:gotoEnd})$0]]></content>
-	<tabTrigger>.stop</tabTrigger>
+	<tabTrigger>stop</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/submit.sublime-snippet
+++ b/submit.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[.submit(${1:function(${2:event}) {
 	${0:// Act on the event}
 \}});]]></content>
-	<tabTrigger>.submit</tabTrigger>
+	<tabTrigger>submit</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/text.sublime-snippet
+++ b/text.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.text(${1:'some text'})$0]]></content>
-	<tabTrigger>.text</tabTrigger>
+	<tabTrigger>text</tabTrigger>
 	<description>.text</description>
 	<scope>source.js</scope>
 </snippet>

--- a/then.sublime-snippet
+++ b/then.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.then(${1:doneCallbacks}, ${2:failCallbacks})$0]]></content>
-	<tabTrigger>.then</tabTrigger>
+	<tabTrigger>then</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/toArray.sublime-snippet
+++ b/toArray.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.toArray()$0]]></content>
-	<tabTrigger>.toArray</tabTrigger>
+	<tabTrigger>toArray</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/toggle-showHide.sublime-snippet
+++ b/toggle-showHide.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.toggle(${1/(^[0-9]+$)|.+/(?1::')/}${1:slow/400/fast}${1/(^[0-9]+$)|.+/(?1::')/})$0]]></content>
-	<tabTrigger>.toggle</tabTrigger>
+	<tabTrigger>toggle</tabTrigger>
 	<description>toggle (show/hide)</description>
 	<scope>source.js</scope>
 </snippet>

--- a/toggleClass.sublime-snippet
+++ b/toggleClass.sublime-snippet
@@ -2,6 +2,6 @@
 	<content><![CDATA[
 .toggleClass('${1:class name}')$0
 		]]></content>
-	<tabTrigger>.toggleClass</tabTrigger>
+	<tabTrigger>toggleClass</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/toggleEvent.sublime-snippet
+++ b/toggleEvent.sublime-snippet
@@ -5,7 +5,7 @@
 	${2:// Stuff to do every *even* time the element is clicked;}
 });
 $0]]></content>
-	<tabTrigger>.toggle</tabTrigger>
+	<tabTrigger>toggle</tabTrigger>
 	<description>.toggle</description>
 	<scope>source.js</scope>
 </snippet>

--- a/trigger.sublime-snippet
+++ b/trigger.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.trigger('${1:event name}')$0]]></content>
-	<tabTrigger>.trigger</tabTrigger>
+	<tabTrigger>trigger</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/triggerHandler.sublime-snippet
+++ b/triggerHandler.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.triggerHandler('${1:event name}')$0]]></content>
-	<tabTrigger>.triggerHandler</tabTrigger>
+	<tabTrigger>triggerHandler</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/unbind.sublime-snippet
+++ b/unbind.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.unbind('${1:event name(s)}'${2/(^,).*|.+/(?1::, )/}${2/(^([0-9]+$|,.*))|.+/(?1::')/}${2:functionName}${2/(^([0-9]+$|,.*))|.+/(?1::')/})$0]]></content>
-	<tabTrigger>.unbind</tabTrigger>
+	<tabTrigger>unbind</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/undelegate.sublime-snippet
+++ b/undelegate.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.undelegate('${1:selector}', '${2:event type}', '${3:function}');]]></content>
-	<tabTrigger>.undelegate</tabTrigger>
+	<tabTrigger>undelegate</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/unwrap.sublime-snippet
+++ b/unwrap.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.unwrap(${1:queueName});$0]]></content>
-	<tabTrigger>.unwrap</tabTrigger>
+	<tabTrigger>unwrap</tabTrigger>
 	<description>.unwrap()</description>
 	<scope>source.js</scope>
 </snippet>

--- a/val.sublime-snippet
+++ b/val.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.val(${1/(.+)/(?1:':)/}${1:text}${1/(.+)/(?1:':)/})$0]]></content>
-	<tabTrigger>.val</tabTrigger>
+	<tabTrigger>val</tabTrigger>
 	<description>.val</description>
 	<scope>source.js</scope>
 </snippet>

--- a/width.sublime-snippet
+++ b/width.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[.width(${1:integer})$0]]></content>
-	<tabTrigger>.width</tabTrigger>
+	<tabTrigger>width</tabTrigger>
 	<description>.width</description>
 	<scope>source.js</scope>
 </snippet>

--- a/wrap.sublime-snippet
+++ b/wrap.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.wrap('${1:&lt;div class="extra-wrapper"&gt;&lt;/div&gt;}')$0]]></content>
-	<tabTrigger>.wrap</tabTrigger>
+	<tabTrigger>wrap</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/wrapAll.sublime-snippet
+++ b/wrapAll.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.wrapAll('${1:&lt;div class="extra-wrapper"&gt;&lt;/div&gt;}')$0]]></content>
-	<tabTrigger>.wrapAll</tabTrigger>
+	<tabTrigger>wrapAll</tabTrigger>
 	<scope>source.js</scope>
 </snippet>

--- a/wrapInner.sublime-snippet
+++ b/wrapInner.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
 	<content><![CDATA[.wrapInner('${1:&lt;div class="extra-wrapper"&gt;&lt;/div&gt;}')$0]]></content>
-	<tabTrigger>.wrapInner</tabTrigger>
+	<tabTrigger>wrapInner</tabTrigger>
 	<scope>source.js</scope>
 </snippet>


### PR DESCRIPTION
Within Sublime Text 2, it seems there's an issue with starting tab triggers with special characters.

The snippets works with tab completion once you type the entire snippet, but the real time autocompletion popups do not work with any snippets that have these tab triggers began by special characters.

This branch simply removes the "." in front of the snippets' tab triggers to allow proper live autocomplete suggestion/popup.
